### PR TITLE
Adding fold on lists

### DIFF
--- a/theories/continuations.v
+++ b/theories/continuations.v
@@ -50,6 +50,7 @@ Inductive cont :=
   | CSome
   | CErrorOnEmpty
   | CDefaultPure
+  | CFold (f: {bind 2 of term}) (ts: list term)
 .
 
 Inductive state :=
@@ -281,6 +282,22 @@ Inductive cred: state -> state -> Prop :=
     cred
       (mode_cont ((CIf t1 t2) :: kappa) sigma (RValue (Bool false)))
       (mode_eval t2 kappa sigma)
+
+  | cred_fold_intro:
+    forall f ts acc kappa sigma,
+    cred
+      (mode_eval (Fold f ts acc) kappa sigma)
+      (mode_eval acc (CFold f ts :: kappa) sigma)
+  | cred_fold_rec:
+    forall f h ts v kappa sigma,
+    cred
+      (mode_cont (CFold f (h::ts) :: kappa) sigma (RValue v))
+      (mode_eval (App (App f h) (Value v)) (CFold f ts :: kappa) sigma)
+  | cred_fold_init:
+    forall f v kappa sigma,
+    cred
+      (mode_cont (CFold f [] :: kappa) sigma (RValue v))
+      (mode_cont kappa sigma (RValue v)) 
 .
 
 Notation "'cred' t1 t2" :=
@@ -524,6 +541,9 @@ Inductive inv_conts_no_hole: cont -> Prop :=
   inv_conts_no_hole CErrorOnEmpty
 | inv_CDefaultPure:
   inv_conts_no_hole CDefaultPure
+| inv_CFold:
+  forall f ts,
+  inv_conts_no_hole (CFold f ts)
 .
 
 Inductive inv_state: state -> Prop :=
@@ -592,6 +612,11 @@ Proof.
   all: try remember (a::kappa) as kappa'.
   all: repeat rewrite droplastn_cons by (subst; simpl; lia).
   all: try solve [econstructor; eauto].
+  {
+    repeat rewrite lastn_def_firstn in *; simpl in *.
+    inj.
+    exfalso; eapply fuck_stdlib; eauto.
+  }
 Qed.
 
 Theorem creds_stack_sub:

--- a/theories/continuations.v
+++ b/theories/continuations.v
@@ -297,7 +297,12 @@ Inductive cred: state -> state -> Prop :=
     forall f v kappa sigma,
     cred
       (mode_cont (CFold f [] :: kappa) sigma (RValue v))
-      (mode_cont kappa sigma (RValue v)) 
+      (mode_cont kappa sigma (RValue v))
+  | cred_fold_conflict:
+    forall f ts kappa sigma,
+    cred
+      (mode_cont (CFold f ts :: kappa) sigma RConflict)
+      (mode_cont kappa sigma RConflict)
 .
 
 Notation "'cred' t1 t2" :=
@@ -454,6 +459,7 @@ Theorem append_stack_stable s s':
   cred (append_stack s k) (append_stack s' k).
 Proof.
   induction 1; intros; asimpl; try econstructor; eauto.
+  repeat intro; inj.
 Qed.
 
 Theorem append_stack_stable_star s s':

--- a/theories/continuations.v
+++ b/theories/continuations.v
@@ -50,7 +50,7 @@ Inductive cont :=
   | CSome
   | CErrorOnEmpty
   | CDefaultPure
-  | CFold (f: {bind 2 of term}) (ts: list term)
+  | CFold (f: term) (ts: list term)
 .
 
 Inductive state :=

--- a/theories/sequences.v
+++ b/theories/sequences.v
@@ -395,21 +395,6 @@ Proof.
     - right; exists a, b; repeat split; eauto; econstructor; eauto.
 Qed.
 
-Lemma takewhile_Prop:
-  forall R U a c,
-  (forall x y, {U x y}+{~ U x y}) ->
-  star R a c ->
-  star (fun a b => R a b /\ U a b) a c \/
-  exists b b',
-  star (fun a b => R a b /\ U a b) a b
-  /\ star R b' c
-  /\ R b b'
-  /\ ~ U b b'.
-Proof.
-  admit.
-Admitted.
-
-
 
 (** Additional properties for deterministic transition relations. *)
 

--- a/theories/simulation_cred_to_sred.v
+++ b/theories/simulation_cred_to_sred.v
@@ -384,4 +384,5 @@ Proof.
     replace t2.[Value v .: subst_of_env sigma] with t2.[up (subst_of_env sigma)].[Value v/] by autosubst.
     econstructor.
   }
+  Fail Next Obligation.
 Admitted.

--- a/theories/simulation_cred_to_sred.v
+++ b/theories/simulation_cred_to_sred.v
@@ -91,6 +91,8 @@ Definition apply_cont
     (ErrorOnEmpty t, sigma)
   | CDefaultPure =>
     (DefaultPure t, sigma)
+  | CFold f ts =>
+    (Fold f.[subst_of_env sigma] ts..[subst_of_env sigma] t, sigma)
   end.
 
 Definition apply_conts

--- a/theories/simulation_sred_to_cred.v
+++ b/theories/simulation_sred_to_cred.v
@@ -133,6 +133,8 @@ Definition apply_cont
     (ErrorOnEmpty t, sigma)
   | CDefaultPure =>
     (DefaultPure t, sigma)
+  | CFold f ts =>
+    (Fold f.[subst_of_env sigma] ts..[subst_of_env sigma] t, sigma)
   end.
 
 Definition apply_conts
@@ -531,6 +533,26 @@ Proof.
   { repeat eexists. }
 Qed.
 
+Lemma subst_of_env_Fold {f ts ti t' env}:
+  Fold f ts ti = t'.[subst_of_env env] ->
+  exists f' ts' ti',
+    f = f'.[subst_of_env env]
+    /\ ts = ts'..[subst_of_env env]
+    /\ ti = ti'.[subst_of_env env]
+    /\ t' = Fold f' ts' ti'
+.
+Proof.
+  destruct t'; asimpl; intros; tryfalse; inj; eauto.
+  { match goal with
+    | [h: _ = subst_of_env ?env ?x |- _ ] =>
+      unfold subst_of_env in h;
+      destruct (List.nth_error env x);
+      inj
+    end.
+  }
+  { repeat eexists. }
+Qed.
+
 Lemma subst_of_env_If {u t1 t2 t' env}:
   If u t1 t2 = t'.[subst_of_env env] ->
   exists u' t1' t2',
@@ -688,6 +710,15 @@ Ltac unpack_subst_of_env_cons :=
     let Ht2 := fresh "Ht2" in
     let Ht := fresh "Ht" in
     destruct (subst_of_env_Match_ h) as (u & t1 & t2 & Hu & Ht1 & Ht2 & Ht); subst; clear h
+  | [h: Fold _ _ _ = _.[subst_of_env _] |- _] =>
+    let f := fresh "f" in
+    let ts := fresh "ts" in
+    let ti := fresh "t" in
+    let Hf := fresh "Hf" in
+    let Hts := fresh "Hts" in
+    let Hti := fresh "Hti" in
+    let Ht := fresh "Ht" in
+    destruct (subst_of_env_Fold h) as (f & ts & ti & Hf & Hts & Hti & Ht); subst; clear h
   | [h: If _ _ _ = _.[subst_of_env _] |- _] =>
     let u := fresh "u" in
     let t1 := fresh "ta" in

--- a/theories/small_step.v
+++ b/theories/small_step.v
@@ -271,7 +271,6 @@ Inductive sred: term -> term -> Prop :=
       sred (ErrorOnEmpty (Value (VPure v))) (Value v)
   | sred_eoe_conflict:
     sred (ErrorOnEmpty Conflict) (Conflict)
-  
 
   | sred_DefaultPure_value:
     forall v,
@@ -282,6 +281,23 @@ Inductive sred: term -> term -> Prop :=
       sred (DefaultPure ta) (DefaultPure tb)
   | sred_DefaultPure_conflit:
     sred (DefaultPure Conflict) Conflict
+
+  | sred_Fold_rec:
+    forall f h t v,
+    sred
+      (Fold f (h::t) (Value v))
+      (Fold f (t) (App (App f h) (Value v)))
+  | sred_Fold_init:
+    forall f v,
+    sred
+      (Fold f ([]) (Value v))
+      (Value v)
+  | sred_Fold_step:
+    forall f ts t1 t2,
+    sred t1 t2 ->
+    sred
+      (Fold f ts t1)
+      (Fold f ts t2)
 .
 
 
@@ -480,6 +496,20 @@ Proof.
   }
 Qed.
 
+Lemma star_sred_fold:
+    forall f ts u1 u2,
+    star sred u1 u2 ->
+      star sred
+        (Fold f ts u1)
+        (Fold f ts u2).
+Proof.
+  induction 1.
+  { eapply star_refl. }
+  { eapply star_step; [|eapply IHstar].
+    econstructor; eauto.
+  }
+Qed.
+
 Hint Resolve
   star_sred_app_left
   star_sred_app_right
@@ -494,6 +524,7 @@ Hint Resolve
   star_sred_empty_empty
   star_sred_erroronempty
   star_sred_defaultpure
+  star_sred_fold
 : sred sred_star.
 
 Hint Constructors sred : sred.

--- a/theories/small_step.v
+++ b/theories/small_step.v
@@ -298,6 +298,11 @@ Inductive sred: term -> term -> Prop :=
     sred
       (Fold f ts t1)
       (Fold f ts t2)
+  | sred_Fold_Conflict:
+    forall f ts ,
+    sred
+      (Fold f ts Conflict)
+      (Conflict)
 .
 
 

--- a/theories/syntax.v
+++ b/theories/syntax.v
@@ -31,7 +31,7 @@ Inductive term :=
   | Match_ (u t1: term) (t2: {bind term})
   | ENone
   | ESome (t: term)
-  | Fold (f: {bind 2 of term}) (ts: list term) (t: term)
+  | Fold (f: term) (ts: list term) (t: term)
 
   | If (t ta tb: term)
 
@@ -245,7 +245,7 @@ Qed.
 
 Lemma fv_Fold_eq:
   forall k f ts acc,
-  fv k (Fold f ts acc)  <-> fv (S (S k)) f /\ (List.Forall (fv k) ts) /\ fv k acc.
+  fv k (Fold f ts acc)  <-> fv k f /\ (List.Forall (fv k) ts) /\ fv k acc.
 Proof.
   unfold fv. intros. asimpl. split; intros.
   { injections. repeat split; eauto.

--- a/theories/syntax.v
+++ b/theories/syntax.v
@@ -31,7 +31,7 @@ Inductive term :=
   | Match_ (u t1: term) (t2: {bind term})
   | ENone
   | ESome (t: term)
-  (* | Fold (f: {bind 2 term}) (ts: list term) (t: term) *)
+  | Fold (f: {bind 2 of term}) (ts: list term) (t: term)
 
   | If (t ta tb: term)
 
@@ -243,6 +243,22 @@ Proof.
     reflexivity. }
 Qed.
 
+Lemma fv_Fold_eq:
+  forall k f ts acc,
+  fv k (Fold f ts acc)  <-> fv (S (S k)) f /\ (List.Forall (fv k) ts) /\ fv k acc.
+Proof.
+  unfold fv. intros. asimpl. split; intros.
+  { injections. repeat split; eauto.
+    { eapply thing; assumption. }
+  }
+  { unpack. rewrite H, H1; repeat f_equal.
+    pose proof (thing ts) as Hrw.
+    rewrite Hrw.
+    eauto.
+  }
+Qed.
+
+
 Lemma fv_Value_eq:
   forall k v,
   fv k (Value v) <-> True.
@@ -263,4 +279,5 @@ Hint Rewrite
   fv_ErrorOnEmpty_eq
   fv_DefaultPure_eq
   fv_Value_eq
+  fv_Fold_eq
   : fv.


### PR DESCRIPTION
This pull request tries an alternative to inline the fold, by adding the fold itself to the semantics of the language. This permit to not have problems with variable lifting in the continuation case.


The two main theorems are closed under global context (only need of `functional_extensionality_dep`)

```coq
Theorem correction_continuations:
  forall s1 s2,
  (exists GGamma Gamma T, jt_state GGamma Gamma s1 T) ->
  cred s1 s2 ->
  exists target,
    star cred
      (trans_state s1) target /\
    star cred
      (trans_state s2) target.
```

and

```coq
Theorem correction_small_steps:
  forall s1 s2,
  (exists GGamma Gamma T, jt_term GGamma Gamma s1 T) ->
  sred s1 s2 ->
  exists target,
    star sred
      (trans s1) target /\
    star sred
      (trans s2) target.
```

The sred and cred are proved equivalent using forward simulation. Two admits are left related to the handling of Closure & Lambda. I will be tackling those issue in a follow-up pull request.

```coq
Theorem simulation_cred_sred:
  forall s1 s2,
    cred s1 s2 ->
    star sred (apply_state s1) (apply_state s2).
```

```coq
Theorem simulation_sred_cred t1 t2:
  sred t1 t2 ->
  forall s1, match_conf s1 t1 -> inv_state s1 ->
  exists s2,
    (plus cred s1 s2)
  /\ match_conf s2 t2 /\ inv_state s2.
```

@sblazy, @denismerigoux could you take a look?