### PR TITLE
implementation of the equivalence between sred and cred in mini-ml

### DIFF
--- a/theories/common.v
+++ b/theories/common.v
@@ -137,6 +137,13 @@ Proof.
 Qed.
 
 
+Lemma nth_error_cons {A} {t: A} {x ts}:
+  List.nth_error (t :: ts ) (S x) = List.nth_error ts x.
+Proof.
+  induction x; simpl; eauto.
+Qed.
+
+
 (* Such that [l = lastn n l ++ firstn n l] *)
 Definition droplastn {A} n (l: list A) := List.firstn ((List.length l) - n) l.
 

--- a/theories/mini.v
+++ b/theories/mini.v
@@ -1,0 +1,310 @@
+Require Export Autosubst.Autosubst.
+Require Export AutosubstExtra.
+Require Import Autosubst_FreeVars.
+Require Import String.
+Require Import Coq.ZArith.ZArith.
+Require Import tactics.
+Import List.ListNotations.
+
+Inductive term :=
+  (* Lambda calculus part of the language*)
+  | Var (x: var)
+  | App (t1 t2: term)
+  | Lam (t: {bind term})
+  | Value (v: value)
+
+with value :=
+  | Closure (t: {bind term}) (sigma: list value)
+.
+
+#[export] Instance Ids_term : Ids term. derive. Defined.
+#[export] Instance Idslemmas_term : IdsLemmas term.
+  econstructor.
+  unfold ids, Ids_term.
+  intros; inj; eauto.
+Defined.
+#[export] Instance Rename_term : Rename term. derive. Defined.
+#[export] Instance Subst_term : Subst term. derive. Defined.
+#[export] Instance SubstLemmas_term : SubstLemmas term. derive. Qed.
+
+Lemma ids_inj:
+  forall x y, ids x = ids y -> x = y.
+intros; inj; eauto.
+Qed.
+
+Inductive cont :=
+  | CAppR (t2: term) (* [\square t2] *)
+  | CClosure (t_cl: {bind term}) (sigma_cl: list value)
+  (* [Clo(x, t_cl, sigma_cl) \square] Since we are using De Bruijn indices,
+     there is no variable x. *)
+  | CReturn (sigma: list value) (* call return *)
+.
+
+Inductive result :=
+  | RValue (v: value)
+.
+
+
+Inductive state :=
+  | mode_eval (e: term) (kappa: list cont) (env: list value)
+  | mode_cont (kappa: list cont) (env: list value) (result: result)
+.
+
+
+Inductive cred: state -> state -> Prop :=
+
+
+  (** Rules related to the lambda calculus *)
+  | cred_var:
+    forall x kappa sigma v,
+    List.nth_error sigma x = Some v ->
+    cred
+      (mode_eval (Var x) kappa sigma)
+      (mode_cont kappa sigma (RValue v))
+
+  | cred_app:
+    forall t1 t2 kappa sigma,
+    cred
+      (mode_eval (App t1 t2) kappa sigma)
+      (mode_eval t1 ((CAppR t2) :: kappa) sigma)
+
+  | cred_clo:
+    forall t kappa sigma,
+    cred
+      (mode_eval (Lam t) kappa sigma)
+      (mode_cont kappa sigma (RValue (Closure t sigma)))
+
+  | cred_arg:
+    forall t2 kappa sigma tcl sigmacl,
+    cred
+      (mode_cont ((CAppR t2)::kappa) sigma (RValue (Closure tcl sigmacl)))
+      (mode_eval t2 ((CClosure tcl sigmacl)::kappa) sigma)
+
+  | cred_beta:
+    forall t_cl sigma_cl kappa sigma v,
+    cred
+      (mode_cont ((CClosure t_cl sigma_cl)::kappa) sigma (RValue v))
+      (mode_eval t_cl (CReturn sigma::kappa)  (v :: sigma_cl))
+
+  | cred_return:
+    forall sigma_cl kappa sigma r,
+    cred
+      (mode_cont (CReturn sigma::kappa) sigma_cl r)
+      (mode_cont kappa sigma r)
+.
+
+Import List.ListNotations.
+Require Import Autosubst_FreeVars.
+Open Scope list.
+
+Definition subst_of_env sigma :=
+  fun n =>
+  match List.nth_error sigma n with
+  | None => ids (n - List.length sigma)
+  | Some t => Value t
+  end
+.
+
+
+Inductive sred: term -> term -> Prop :=
+  | sred_lam:
+    forall t,
+      sred
+        (Lam t)
+        (Value (Closure t []))
+
+  | sred_beta:
+    forall t v sigma',
+      sred
+        (App (Value (Closure t sigma')) (Value v))
+        (t.[subst_of_env (v :: sigma')])
+  | sred_app_right:
+    forall t u1 u2 sigma,
+      sred (u1) (u2) ->
+      sred
+        (App (Value (Closure t sigma)) u1)
+        (App (Value (Closure t sigma)) u2)
+  | sred_app_left:
+    forall t1 t2 u,
+      sred (t1) (t2) ->
+      sred
+        (App t1 u)
+        (App t2 u)
+.
+
+Require Import sequences.
+
+
+Definition apply_cont
+  (param1: term * list value)
+  (k: cont)
+  : term * list value :=
+  let '(t, sigma) := param1 in
+  match k with
+  | CAppR t2 =>
+    (App t t2.[subst_of_env sigma], sigma)
+  | CClosure t_cl sigma_cl =>
+    (App (Value (Closure t_cl sigma_cl)) t, sigma)
+  | CReturn sigma' => (t, sigma')
+  end.
+
+Definition apply_conts
+  (kappa: list cont)
+  : term * list value -> term * list value :=
+  List.fold_left apply_cont kappa.
+
+Definition apply_return (r: result) :=
+  match r with
+  | RValue v => Value v
+  end.
+
+Definition apply_state_aux (s: state): term * list value :=
+  match s with
+  | mode_eval t stack env =>
+    (apply_conts stack (t.[subst_of_env env], env))
+  | mode_cont stack env r =>
+    (apply_conts stack ((apply_return r),env))
+  end.
+  
+(* We use an notation to be apple to simplify this definition. *)
+Notation "'apply_state' s" := (fst (apply_state_aux s)) (at level 50, only parsing).
+
+Inductive inv_value: value -> value -> Prop :=
+.
+
+Inductive inv_state: state -> term -> Prop :=
+  | InvBase: forall s,
+    inv_state s (apply_state s)
+  | InvValue: forall s v v',
+    inv_state s (Value v) ->
+    inv_value v v' ->
+    inv_state s (Value v')
+.
+
+Lemma apply_conts_app:
+  forall kappa1 kappa2 p,
+    apply_conts (kappa1 ++ kappa2) p
+    = apply_conts kappa2 (apply_conts kappa1 p).
+Proof.
+  intros.
+  unfold apply_conts.
+  rewrite List.fold_left_app; eauto.
+Qed.
+
+Fixpoint last (l: list cont) (env0: list value) : list value :=
+  match l with
+  | [] => env0
+  | CReturn env1 :: l =>
+    last l env1
+  | _ :: l =>
+    last l env0
+  end.
+
+Lemma last_snd_apply_conts :
+  forall kappa env0 t, (snd (apply_conts kappa (t, env0))) = (last kappa env0).
+Proof.
+  induction kappa.
+  { simpl; eauto. }
+  { induction a; simpl; intros; eauto. }
+Qed.
+
+Theorem sred_apply_conts: forall kappa t t' sigma,
+  sred t t' ->
+  sred
+    (fst (apply_conts kappa (t, sigma)))
+    (fst (apply_conts kappa (t', sigma)))
+.
+Proof.
+  induction kappa as [|k kappa] using List.rev_ind.
+  { induction 1; simpl; econstructor; eauto. }
+  { induction k; intros t t' env Htt'.
+
+    all: pose proof (IHkappa _ _ env Htt').
+    all: repeat rewrite apply_conts_app;
+    simpl; unfold apply_cont; repeat match goal with
+    | [ |- context [let '(_, _) := ?p in _]] =>
+      rewrite (surjective_pairing p)
+    | [h: context [let '(_, _) := ?p in _] |- _] =>
+      rewrite (surjective_pairing p) in h
+    end; simpl.
+
+    all: repeat rewrite last_snd_apply_conts.
+    
+    all: try econstructor; eauto.
+  }
+Qed.
+
+Theorem star_sred_apply_conts: forall kappa t t' sigma,
+  star sred t t' ->
+  star sred
+    (fst (apply_conts kappa (t, sigma)))
+    (fst (apply_conts kappa (t', sigma)))
+.
+Proof.
+  induction 1; econstructor; eauto using sred_apply_conts.
+Qed.
+
+Lemma inv_state_value:
+  forall s t,
+  inv_state s t ->
+  forall v, t = Value v ->
+  exists v',
+    star inv_value v' v /\ apply_state s = Value v'.
+Proof.
+  induction 1.
+  { eexists; split; eauto. econstructor. }
+  { intros; inj; subst.
+    edestruct IHinv_state; eauto; unpack.
+    eexists; split; eauto.
+    eauto with sequences.
+  }
+Qed.
+
+Definition sym {T} R (x y:T) := R x y \/ R y x.
+
+Lemma inv_state_nvalue_aux:
+  forall s t,
+  inv_state s t ->
+  forall v1, t = Value v1 ->
+  forall t2, inv_state s t2 ->
+  exists v2, t2  = Value v2 /\ star (sym inv_value) v1 v2.
+Proof.
+  unfold sym.
+  induction 1.
+  { intros v1 Hv1.
+    induction 1.
+    { eexists; split; eauto with sequences. }
+    { destruct IHinv_state as [v0 ?]; eauto; unpack.
+      inj; subst.
+      eexists; split; eauto.
+      eapply star_step_n1; eauto.
+    }
+  }
+  {
+    intros; inj; subst.
+    edestruct IHinv_state as [v2 ?]; eauto; unpack; subst.
+    eexists; split; eauto.
+    eapply star_step; eauto.
+  }
+Qed.
+
+Lemma 
+
+Theorem simulation_cred_sred:
+  forall s1 s2,
+    cred s1 s2 ->
+    forall t1,
+    inv_state s1 t1 ->
+    exists t2,
+    inv_state s2 t2 /\ star sred t1 t2.
+Proof.
+  induction 1.
+  all: intros tt1 IHt1.
+  all: inversion IHt1; subst; clear IHt1.
+  all: simpl.
+  
+  2: { eexists; split; [|eapply star_refl].
+    pose proof (inv_state_nvalue _ _ H0).
+
+  }
+Qed.

--- a/theories/mini.v
+++ b/theories/mini.v
@@ -956,5 +956,15 @@ Theorem simulation_sred_cred:
       exists s2,
         inv_state s2 t2 /\ star cred s1 s2.
 Proof.
-  
+  intros ? ? Ht1t2 ? Hs1t1.
+  learn (inversion_inv_state _ _ Hs1t1); unpack; subst; clear Hs1t1.
+  learn (proper_inv_state_sred _ _ Ht1t2 _ H); unpack.
+  learn (simulation_sred_cred_base _ _ H1); unpack; subst.
+  eexists; split; eauto.
+  learn (inversion_inv_state _ _ H2); unpack; subst; clear H2.
+  eapply inv_state_from_equiv.
+  symmetry.
+  etransitivity; eauto.
+Qed.
+
   

--- a/theories/mini.v
+++ b/theories/mini.v
@@ -738,7 +738,7 @@ Proof.
   }
   { learn (IHsred _ H5); unpack.
     inversion H3; subst.
-    inversion H6; subst.
+    inversion H7; subst.
     repeat econstructor; eauto.
   }
   {
@@ -780,7 +780,7 @@ Proof.
   | [h: inv_state  _ _ |- _] =>
     learn (inversion_inv_state _ _ h); unpack; subst
   end.
-  learn (proper_inv_state_star_sred _ _ H0 _ (symmetry H2)); unpack.
+  learn (proper_inv_state_star_sred _ _ H1 _ (symmetry H4)); unpack.
   eexists; split; [|eauto].
   eapply inv_state_from_equiv.
   etransitivity; [symmetry|]; eauto.
@@ -1124,7 +1124,7 @@ Proof.
         rewrite apply_state_append_stack; simpl; unfold apply_cont; sp; simpl.
         econstructor; eauto; try reflexivity.
         { learn (inversion_inv_state _ _ H); unpack; subst; symmetry; eauto. }
-        { learn (star_cred_snd_apply_sate H0); simpl in *; subst.
+        { learn (star_cred_snd_apply_sate H2); simpl in *; subst.
           reflexivity.
         }
       }
@@ -1285,9 +1285,9 @@ Proof.
   intros ? ? Ht1t2 ? Hs1t1.
   learn (inversion_inv_state _ _ Hs1t1); unpack; subst; clear Hs1t1.
   learn (proper_inv_state_sred _ _ Ht1t2 _ H); unpack.
-  learn (simulation_sred_cred_base _ _ H1); unpack; subst.
+  learn (simulation_sred_cred_base _ _ H3); unpack; subst.
   eexists; split; eauto.
-  learn (inversion_inv_state _ _ H2); unpack; subst; clear H2.
+  learn (inversion_inv_state _ _ H4); unpack; subst; clear H2.
   eapply inv_state_from_equiv.
   symmetry.
   etransitivity; eauto.

--- a/theories/mini.v
+++ b/theories/mini.v
@@ -524,6 +524,21 @@ Notation "'sim_value' t1 t2" :=
   format "'sim_value'  '[hv' t1  '/' t2 ']'"
 ).
 
+Lemma subst_of_env_nil_ids:
+  subst_of_env [] = ids.
+Proof.
+  eapply FunctionalExtensionality.functional_extensionality.
+  induction x; unfold subst_of_env; simpl; eauto.
+Qed.
+
+Lemma subst_env_cons v sigma:
+  subst_of_env (v :: sigma) = (Value v) .: subst_of_env sigma.
+Proof.
+  eapply FunctionalExtensionality.functional_extensionality.
+  induction x; asimpl; eauto.
+Qed.
+
+
 Lemma proper_inv_state_sred:
   forall t1 t2,
     sred t1 t2 ->
@@ -534,11 +549,18 @@ Lemma proper_inv_state_sred:
 Proof.
   induction 1; inversion 1; subst.
   { repeat econstructor.
-    admit "need subst related ".
+    rewrite subst_of_env_nil_ids.
+    rewrite up_id; asimpl.
+    eauto.
   }
   { inversion H2; inversion H4; inversion H1; subst.
-    repeat econstructor. 
-    admit "need subst related inv_term".
+    repeat econstructor.
+    clear -H6 H11.
+    replace (t.[subst_of_env (v :: sigma')]) with t.[up (subst_of_env sigma')].[Value v/] by (rewrite subst_env_cons; asimpl; eauto).
+    replace (t2.[subst_of_env (w0 :: sigma2)]) with t2.[up (subst_of_env sigma2)].[Value w0/] by (rewrite subst_env_cons; asimpl; eauto).
+    eapply sim_term_subst; eauto.
+    { induction x; simpl; econstructor; eauto. }
+    
   }
   { learn (IHsred _ H5); unpack.
     inversion H3; subst.

--- a/theories/mini.v
+++ b/theories/mini.v
@@ -965,6 +965,12 @@ Proof.
   simpl; eauto.
 Qed.
 
+Lemma apply_conts_Value_apply_state {v kappa env}:
+(fst (apply_conts kappa (Value v, env))) = apply_state (mode_cont kappa env (RValue v)).
+Proof.
+  simpl; eauto.
+Qed.
+
 
 
 Theorem simulation_sred_cred_base:
@@ -1050,6 +1056,7 @@ Proof.
     all: try solve [
       eapply star_refl_prop; eapply inv_state_from_equiv; simpl; unfold apply_cont; sp; simpl; reflexivity
     ].
+    all: try match goal with [|-context [CReturn ]] => admit end.
     { rewrite subst_apply_state in Ht2t3.
       epose proof (IHlen _ _ _ _ _ Ht2t3); unpack.
 
@@ -1114,18 +1121,50 @@ Proof.
     {
       inversion Ht2t3.
     }
-    { admit. }
-    { admit. }
-    { admit. }
-    { admit. }
-    { admit. }
-    { admit. }
-    { admit. }
-    { admit. }
-    { admit. }
-    { admit. }
-    { admit. }
-    { admit. }
+    { rewrite subst_apply_state in Ht2t3.
+      epose proof (IHlen _ _ _ _ _ Ht2t3); unpack.
+
+      match goal with
+      | [h:inv_state _ _ |- _] => learn (inversion_inv_state _ _ h); clear h; unpack; subst
+      end.
+
+      eapply star_trans_prop; [rewrite append_stack_all; eapply star_cred_append_stack; eauto|simpl].
+
+      eapply star_refl_prop.
+      eapply inv_state_from_equiv; rewrite apply_state_append_stack; simpl; unfold apply_cont; sp; simpl.
+      econstructor; first[reflexivity| symmetry; eauto].
+    }
+    { rewrite apply_conts_Value_apply_state in Ht2t3.
+      epose proof (IHlen _ _ _ _ _ Ht2t3); unpack.
+
+      match goal with
+      | [h:inv_state _ _ |- _] => learn (inversion_inv_state _ _ h); clear h; unpack; subst
+      end.
+
+      eapply star_trans_prop; [erewrite append_stack_app; [|solve[simpl; eauto]]; eapply star_cred_append_stack; eauto|simpl with_stack].
+      
+      eapply star_refl_prop.
+      eapply inv_state_from_equiv; rewrite apply_state_append_stack; simpl; unfold apply_cont; sp; simpl.
+      econstructor; [symmetry; eauto|].
+      pose proof (star_cred_snd_apply_sate H0); simpl in *; rewrite snd_apply_conts_last in *; rewrite H1.
+      reflexivity.
+    }
+    { rewrite apply_conts_Value_apply_state in Ht2t3.
+      epose proof (IHlen _ _ _ _ _ Ht2t3); unpack.
+
+      match goal with
+      | [h:inv_state _ _ |- _] => learn (inversion_inv_state _ _ h); clear h; unpack; subst
+      end.
+
+      eapply star_trans_prop; [erewrite append_stack_app; [|solve[simpl; eauto]]; eapply star_cred_append_stack; eauto|simpl with_stack].
+
+      eapply star_refl_prop.
+      eapply inv_state_from_equiv; rewrite apply_state_append_stack; simpl; unfold apply_cont; sp; simpl.
+      econstructor; first [reflexivity|symmetry; eauto].
+    }
+    {
+      inversion Ht2t3.
+    }
   }
 Admitted.
 
@@ -1148,5 +1187,3 @@ Proof.
   symmetry.
   etransitivity; eauto.
 Qed.
-
-  

--- a/theories/mini.v
+++ b/theories/mini.v
@@ -893,32 +893,6 @@ Ltac subst_of_env :=
     learn (subst_of_env_Value h); clear h; unzip; subst
   end.
 
-Lemma star_refl_prop { A } { R: A -> A -> Prop}{P s1}:
-  P s1 ->
-  (exists s, P s /\ star R s1 s).
-Proof.
-  intros; unpack; eexists; split; eauto.
-  eapply star_refl; eauto.
-Qed.
-
-Lemma star_step_prop { A } { R: A -> A -> Prop}{P s1 s2}:
-  R s1 s2 ->
-  (exists s, P s /\ star R s2 s) ->
-  (exists s, P s /\ star R s1 s).
-Proof.
-  intros; unpack; eexists; split; eauto.
-  eapply star_step; eauto.
-Qed.
-
-Lemma star_trans_prop { A } { R: A -> A -> Prop}{P s1 s2}:
-  star R s1 s2 ->
-  (exists s, P s /\ star R s2 s) ->
-  (exists s, P s /\ star R s1 s).
-Proof.
-  intros; unpack; eexists; split; eauto.
-  eapply star_trans; eauto.
-Qed.
-
 Lemma cred_snd_apply_sate {s1 s2}:
   cred s1 s2 ->
   snd (apply_state_aux s1) = snd (apply_state_aux s2).

--- a/theories/mini.v
+++ b/theories/mini.v
@@ -44,27 +44,6 @@ intros; inj; eauto.
 Qed.
 
 
-
-Scheme term_value_ind := Induction for term Sort Prop
-  with value_term_ind := Induction for value Sort Prop.
-
-
-Theorem term_indudction
-	 : forall (P : term -> Prop) (P0 : value -> Prop),
-       (forall x : var, P (Var x)) ->
-       (forall t1 : term, P t1 -> forall t2 : term, P t2 -> P (App t1 t2)) ->
-       (forall t : {bind term}, P t -> P (Lam t)) ->
-       (forall v : value, P0 v -> P (Value v)) ->
-       (forall t : {bind term},
-        P t -> forall sigma : list value, P0 (Closure t sigma)) ->
-       (forall t : term, P t) /\ forall v : value, P0 v.
-Proof.
-  split.
-  eapply term_value_ind; eauto.
-  eapply value_term_ind; eauto.
-Qed.
-
-
 (* Strong induction principle for terms *)
 
 Program Fixpoint size_term t := 
@@ -129,7 +108,7 @@ Proof.
   }
 Qed.
 
-Theorem term_indudction'
+Theorem term_ind'
   : forall (P : term -> Prop) (P0 : value -> Prop),
       (forall x : var, P (Var x)) ->
       (forall t1 : term, P t1 -> forall t2 : term, P t2 -> P (App t1 t2)) ->
@@ -385,7 +364,7 @@ Qed.
 
 
 Lemma sim_term_reflexive: Reflexive sim_term /\ Reflexive sim_value.
-  eapply term_indudction'.
+  eapply term_ind'.
   all: econstructor; eauto.
   {
     eapply sim_term_subst.

--- a/theories/mini.v
+++ b/theories/mini.v
@@ -152,9 +152,56 @@ with sim_value: value -> value -> Prop :=
     sim_value (Closure t1 sigma1) (Closure t2 sigma2)
 .
 
+Scheme term_value_ind := Induction for term Sort Prop
+with value_term_ind := Induction for value Sort Prop.
+
+Scheme sim_term_sim_value_ind := Induction for sim_term Sort Prop
+with sim_value_sim_term_ind := Induction for sim_value Sort Prop.
+
+Check sim_term_sim_value_ind.
+
 (* this is obviously an equivalence relation. *)
 
 Require Import Coq.Classes.SetoidClass.
+
+Lemma sim_term_ren:
+  forall t1 t2,
+    sim_term t1 t2 ->
+    forall xi,
+      sim_term t1.[ren xi] t2.[ren xi].
+Proof.
+  induction 1; intros; subst; asimpl.
+  all: try econstructor; eauto.
+Qed.
+
+Lemma sim_term_subst:
+  forall t1 t2,
+    sim_term t1 t2 ->
+    forall sigma1 sigma2,
+      (forall x, sim_term (sigma1 x) (sigma2 x)) ->
+      sim_term t1.[sigma1] t2.[sigma2].
+Proof.
+  induction 1; intros; subst; asimpl.
+  all: try econstructor; eauto.
+  { eapply IHsim_term.
+    induction x; asimpl.
+    { econstructor; eauto. }
+    { eapply sim_term_ren; eauto. }
+  }
+Qed.
+
+Lemma sim_term_reflexive: Reflexive sim_term.
+  intro.
+  einduction x using term_value_ind.
+  1-4: econstructor; eauto.
+  { eapply IHt. }
+  { simpl.
+    econstructor.
+    eapply sim_term_subst; eauto.
+    induction x0; asimpl.
+    { econstructor; eauto. }
+    { eapply sim_term_ren. (* this is false. *) }
+  }
 
 Instance Reflexive_sim_term : Reflexive sim_term. Admitted.
 Instance Transtive_sim_term : Transitive sim_term. Admitted.

--- a/theories/sequences.v
+++ b/theories/sequences.v
@@ -157,9 +157,10 @@ Qed.
 Lemma star_step_prop {R P a b}:
   R a b ->
   (exists c, P c /\ star R b c) ->
-  (exists c, P c /\ star R b c).
+  (exists c, P c /\ star R a c).
 Proof.
   intros; unpack; eexists; split; eauto.
+  eapply star_step; eauto.
 Qed.
 
 Lemma star_trans_prop { R P a b}:
@@ -327,11 +328,11 @@ Proof.
   (P := fun a => exists b, star R a b /\ P b).
   (* Proof that the invariant is preserved. *)
   { clear dependent a.
-  intros a (b&hStar&hPb).
-  inversion hStar; subst.
-  { destruct (Hinv b hPb) as [c [hPlus ?]].
-    inversion hPlus; subst. eauto. }
-  { eauto. }
+    intros a (b&hStar&hPb).
+    inversion hStar; subst.
+    { destruct (Hinv b hPb) as [c [hPlus ?]].
+      inversion hPlus; subst. eauto. }
+    { eauto. }
   }
   (* Proof that the invariant initially holds. *)
   { eauto with star. }

--- a/theories/sequences.v
+++ b/theories/sequences.v
@@ -144,6 +144,34 @@ Proof.
   induction 2; eauto.
 Qed.
 
+(* Smart constructors for forward simulation diagrams *)
+
+Lemma star_refl_prop {P R a}:
+  P a ->
+  (exists b, P b /\ star R a b).
+Proof.
+  intros; unpack; eexists; split; eauto.
+  eapply star_refl; eauto.
+Qed.
+
+Lemma star_step_prop {R P a b}:
+  R a b ->
+  (exists c, P c /\ star R b c) ->
+  (exists c, P c /\ star R b c).
+Proof.
+  intros; unpack; eexists; split; eauto.
+Qed.
+
+Lemma star_trans_prop { R P a b}:
+  star R a b ->
+  (exists c, P c /\ star R b c) ->
+  (exists c, P c /\ star R a c).
+Proof.
+  intros; unpack; eexists; split; eauto.
+  eapply star_trans; eauto.
+Qed.
+
+
 (** One or several transitions: transitive closure of [R]. *)
 
 Inductive plus R: A -> A -> Prop :=

--- a/theories/tactics.v
+++ b/theories/tactics.v
@@ -344,3 +344,12 @@ Goal forall n, exists n', n' = n+1.
   eauto.
 Qed.
 
+
+Ltac sp :=
+  repeat match goal with
+  | [ |- context [let '(_, _) := ?p in _]] =>
+    rewrite (surjective_pairing p)
+  | [h: context [let '(_, _) := ?p in _] |- _] =>
+    rewrite (surjective_pairing p) in h
+  end
+.

--- a/theories/tactics.v
+++ b/theories/tactics.v
@@ -54,6 +54,24 @@ Ltac unpack :=
       destruct h
     end.
 
+Ltac unzip :=
+  repeat match goal with
+  | [h: _ /\ _ |- _ ] =>
+    destruct h
+  | [h: _ \/ _ |- _ ] =>
+    destruct h
+  |[h: exists x, _ |- _] =>
+    let x := fresh x in
+    destruct h as [x h]
+  |[h: List.Forall _ (_ :: _) |- _] =>
+    inversion h;
+    subst;
+    clear h
+  |[h: List.Forall _ (_ ++ _) |- _] =>
+    rewrite List.Forall_app in h;
+    destruct h
+  end.
+
 Section unpack_tests.
   Example unpacking_forall_ex1 {A} (P: A -> Prop) l1 l2:
     List.Forall P (l1 ++ l2)

--- a/theories/tactics.v
+++ b/theories/tactics.v
@@ -229,8 +229,7 @@ Module Learn.
       fail 0 "already knew" P "through" Hlearnt
     | _ =>
       pose proof H;
-      let l := fresh "L" in
-      pose proof (AlreadyLearnt H) as l
+      pose proof (AlreadyLearnt H)
     end.
 
   Tactic Notation "learn" constr(H) := learn_fact H.

--- a/theories/tactics.v
+++ b/theories/tactics.v
@@ -209,7 +209,10 @@ Module Learn.
     but unifiable type term *)
     | [ Hlearnt: @Learnt P |- _ ] =>
       fail 0 "already knew" P "through" Hlearnt
-    | _ => pose proof H; pose proof (AlreadyLearnt H)
+    | _ =>
+      pose proof H;
+      let l := fresh "L" in
+      pose proof (AlreadyLearnt H) as l
     end.
 
   Tactic Notation "learn" constr(H) := learn_fact H.


### PR DESCRIPTION
this pull request present miniml, a minimized version of catala with no default, and only some constructors of the main language. In this file, we prove the equivalence between small steps and big steps using an invariant sim_term that make sure closure are invariant with respect to beta-substitution : 

`sim_term t1.[up (subst_of_env sigma1)] t2.[up (subst_of_env sigma2)] -> sim_value (Closure t1 sigma1) (Closure t2 sigma2)`

Here is the two main theorems:

```coq
Theorem simulation_sred_cred:
  forall t1 t2,
    sred t1 t2 ->
    forall s1,
      inv_state s1 t1 ->
      exists s2,
        inv_state s2 t2 /\ star cred s1 s2.

Theorem simulation_cred_sred:
  forall s1 s2,
    cred s1 s2 ->
    forall t1,
      inv_state s1 t1 ->
      exists t2,
        inv_state s2 t2 /\ star sred t1 t2.
```

they are proved by lifting base theorem (without inv_state) thanks to the fact that sred is an morphism with respect to this invariant:

```coq
Lemma proper_inv_state_star_sred:
  forall t1 t2,
    star sred t1 t2 ->
    forall u1,
      sim_term t1 u1 ->
      exists u2,
        sim_term t2 u2 /\ star sred u1 u2.
```

Special engineering was done to simplify the proof, especially the `star_step_prop` and `star_trans_prop` lemmas.


@sblazy 
@denismerigoux 