### PR TITLE
Expressible values miniml

### DIFF
--- a/theories/common.v
+++ b/theories/common.v
@@ -140,3 +140,20 @@ Proof.
   rewrite <- nth_error_Some in *.
   repeat intro; tryfalse.
 Qed.
+
+Lemma nth_error_alt_def {A: Type} {l: list A} {n}:
+    if (n <? Datatypes.length l)%nat
+    then exists v, nth_error l n = Some v
+    else nth_error l n = None.
+Proof.
+  induction (Nat.ltb_spec n (Datatypes.length l)).
+  { learn (proj2 (List.nth_error_Some l n) H).
+    induction (nth_error l n).
+    { exists a; eauto. }
+    { tryfalse. }
+  }
+  { learn (proj2 (List.nth_error_None l n) H).
+    eauto.
+  }
+Qed.
+

--- a/theories/miniml/miniml.v
+++ b/theories/miniml/miniml.v
@@ -1983,6 +1983,7 @@ Ltac inversions :=
   }
 
   { intros.
+    lock H.
     repeat inversions; cleanup.
    
     all: repeat (eapply star_step_prop; [solve[repeat econstructor; eauto]|]).
@@ -2011,8 +2012,14 @@ Ltac inversions :=
     eapply star_refl_prop;
     rewrite apply_state_append_stack; simpl apply_conts;
     repeat f_equal; eauto].
-    
-    
-    all: admit.
+    { unlock H.
+      simpl in H.
+      inversion H.
+    }
+    { unlock H.
+      simpl in H.
+      inversion H.
+    }
   }
-Admitted.
+Qed.
+

--- a/theories/miniml/miniml.v
+++ b/theories/miniml/miniml.v
@@ -1120,21 +1120,6 @@ Theorem preservation_trad t1:
 Proof.
   intros Hfv.
   induction 1; intros; repeat inv_jt; repeat econs_jt; eauto.
-  (* { ugly thing is here. Untold invarant : the terms are free of variables inside lambda.
-    rewrite fv_App_eq in Hfv.
-    rewrite fv_Lam_eq in Hfv.
-    admit.
-    (* progress replace [T1] with (List.firstn 1 (T1::Gamma)) by (simpl; eauto).
-    eapply jt_term_firstn_fv; eauto. *)
-  } *)
-  (* { 
-    (* should be provable with substitution lemma *)
-    (* assert (H: List.Forall2 jt_value (v :: sigma') (T1 :: Gamma_cl)) by (econstructor; eauto). *)
-    (* pose proof (jt_term_subst H3 _ H). *)
-    replace Gamma with ([] ++ Gamma) by (simpl; eauto).
-    (* apply jt_term_more_env. *)
-    eauto.
-  } *)
   { unfold subst.
     replace (Value v .: ids) with (fun n => soe [v] n).
     2: {
@@ -1174,8 +1159,8 @@ Theorem sred_deterministic:
   forall t1 t2, sred t1 t2 -> forall t2', sred t1 t2' -> t2 = t2'.
 Proof.
   induction 1; inversion 1; subst; simpl in *; eauto.
-  { inversion H4; subst; tryfalse. }
-  { inversion H4; subst; tryfalse. }
+  { inversion H3; subst; tryfalse. }
+  { inversion H3; subst; tryfalse. }
   { inversion H; subst; tryfalse. }
   { repeat f_equal. eapply IHsred. eauto. }
   { inversion H4; subst; tryfalse. }

--- a/theories/miniml/miniml_ifthenelse.v
+++ b/theories/miniml/miniml_ifthenelse.v
@@ -1214,6 +1214,30 @@ Ltac2 sinv_cong () :=
 
 Ltac sinv_cong := ltac2: (sinv_cong ()).
 
+
+Theorem cong_term_correctness:
+  forall t1 t2,
+    sred t1 t2 ->
+    forall t1',
+      cong_term t1 t1' ->
+      exists t2',
+        cong_term t2 t2'
+        /\ star sred t1' t2'.
+Proof.
+  induction 1; inversion 1; subst.
+  { eapply star_step_prop. { solve[repeat (econstructor; eauto)]. }
+    eapply star_refl_prop.
+    repeat (econstructor; eauto). 
+  }
+  { repeat sinv_cong.
+    eapply star_step_prop. { solve[repeat (econstructor; eauto)]. }
+    eapply star_refl_prop.
+    repeat (econstructor; eauto).
+    admit "subst lemma".  
+  }
+  all: admit.
+Abort.
+
 (* -------------------------------------------------------------------------- *)
 (** Some properties about cong_term and cong_value. *)
 


### PR DESCRIPTION
This PR add a difference between values and expressible values in miniml, namely, we go from

```coq
Inductive term :=
  | Var (x: var)
  | App (t1 t2: term)
  | Lam (t: {bind term})
  | Value (v: value)

with value :=
  | Closure (t: {bind term}) (sigma: list value)
.
```

to
```coq
Inductive term :=
  | Var (x: var)
  | App (t1 t2: term)
  | Value (v: value)
with value :=
  | Lam (t: {bind term}).

Inductive expressible_value :=
  | Closure (t: {bind term}) (sigma: list expressible_value).
```

While this PR only modify the miniml file, it simplify the development, including of the proof of synchronization between tss and cbss. Indeed, this change remove some hacks that forced us to use a more general invariant to make closures equivalent modulo substitution.

Moreover, the proof is simpler because of the automation techniques learned doing all the other proofs.

As a side note, the syntactical difference between term and values adds extra difficulties in the proof, since we need to hand-build induction principles for the mutual induction, and autosubst does not fill out the substitution correctly (it forget the substitution on values). This make it harder to show new stuff.